### PR TITLE
RFC: source & sink: fix get_freq_corr() calling wrong function

### DIFF
--- a/lib/sink_impl.cc
+++ b/lib/sink_impl.cc
@@ -111,7 +111,7 @@ namespace gr {
     double sink_impl::get_freq_corr(size_t chan)
     {
         return chan < get_num_channels() ?
-                    device_->get_center_freq(chan) : 0;
+                    device_->get_freq_corr(chan) : 0;
     }
 
     std::vector<std::string> sink_impl::get_gain_names(size_t chan)

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -136,7 +136,7 @@ namespace gr {
     double source_impl::get_freq_corr(size_t chan)
     {
         return chan < get_num_channels() ?
-                    device_->get_center_freq(chan) : 0;
+                    device_->get_freq_corr(chan) : 0;
     }
 
     std::vector<std::string> source_impl::get_gain_names(size_t chan)


### PR DESCRIPTION
Not sure, may be I don't see something important, but it looks like we call wrong get functions for correction.

Both source_impl and sink_impl::get_freq_corr() were delegating to get_center_freq() instead of get_freq_corr(), causing callers to receive the tuned centre frequency (Hz) instead of the PPM correction value.