### PR TITLE
grc: fix buflen/buffers visibility tied to wrong condition

### DIFF
--- a/grc/gen_bladerf_blocks.py
+++ b/grc/gen_bladerf_blocks.py
@@ -111,13 +111,13 @@ parameters:
   label: 'Buffer Size'
   dtype: real
   default: 4096
-  hide: ${'$'}{ 'none' if use_ref_clk == 'True' else 'part'}
+  hide: part
 
 - id: buffers
   label: 'Number of Buffers'
   dtype: real
   default: 512
-  hide: ${'$'}{ 'none' if use_ref_clk == 'True' else 'part'}
+  hide: part
 
 - id: in_clk
   label: 'Input clock'


### PR DESCRIPTION
The buflen and buffers parameters were copy-pasted from ref_clk and still used use_ref_clk as their visibility condition, hiding them unless the reference clock was enabled. These are independent parameters, so use unconditional 'part' hide like other advanced settings.