### PR TITLE
bladerf_common: fix null pointer dereference in init_refclk()

### DIFF
--- a/lib/bladerf/bladerf_common.cc
+++ b/lib/bladerf/bladerf_common.cc
@@ -622,6 +622,7 @@ void bladerf_common::init_refclk(int freq)
     if (status != 0) {
       BLADERF_WARNING("bladerf_get_pll_refclk_range: "
                       << bladerf_strerror(status));
+      return;
     }
     if (freq < range->min || freq > range->max)
     {


### PR DESCRIPTION
If bladerf_get_pll_refclk_range() fails, range remains nullptr. The subsequent range->min/max dereference then causes undefined behavior. Return early on error instead of falling through.