### PR TITLE
grc: fix out_clk options using bare YAML booleans instead of strings

### DIFF
--- a/grc/gen_bladerf_blocks.py
+++ b/grc/gen_bladerf_blocks.py
@@ -129,8 +129,8 @@ parameters:
 - id: out_clk
   label: 'Output clock'
   dtype: enum
-  default: False
-  options: [False, True]
+  default: 'False'
+  options: ['False', 'True']
   option_labels: ['Disable', 'Enable']
   
 - id: use_dac


### PR DESCRIPTION
The out_clk parameter used unquoted False/True, which YAML parses as booleans rather than the string values every other enum parameter uses. Quote them to be consistent with the rest of the block definition.